### PR TITLE
Fix: Android cannot send requests to backend

### DIFF
--- a/frontend/hooks/useBuildAPIURL.ts
+++ b/frontend/hooks/useBuildAPIURL.ts
@@ -7,8 +7,6 @@ export const API_URL = Platform.OS === "ios" ? process.env.EXPO_PUBLIC_API_URL :
  * @param path The path of the API request
  * @returns The full API url to a endpoint specified by the path
  */
-export function buildAPIURL(path: string) : string {
-    const apiUrl = process.env.EXPO_PUBLIC_API_URL;
-    
-    return apiUrl + (path.charAt(0) != '/' ? '/' : '') + path;
+export function buildAPIURL(path: string) : string {    
+    return API_URL + (path.charAt(0) != '/' ? '/' : '') + path;
 }


### PR DESCRIPTION
Fixed issue where android cannot send requests to backend server because it was not using API_URL variable in buildAPIURL method.